### PR TITLE
WIP: Easier interface to compute rolling hashes over windows of a given size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,6 @@ impl io::Write for FixedSizeAdler32 {
             total_size
         };
         let buf = &buf[(total_size - size)..];
-        println!("size = {}", size);
 
         // Remove old bytes
         let start = buffer_size + self.position - self.size;
@@ -243,11 +242,7 @@ impl io::Write for FixedSizeAdler32 {
         } else {
             0
         };
-        println!("remove = {}", remove);
         for i in 0..remove {
-            println!("Removing [{}] = '{}' ({})", (start + i) % buffer_size,
-                     self.buffer[(start + i) % buffer_size] as char,
-                     self.size - i);
             self.adler32.remove(
                 self.size - i,
                 self.buffer[(start + i) % buffer_size]);
@@ -255,7 +250,6 @@ impl io::Write for FixedSizeAdler32 {
         self.size -= remove;
 
         // Add new bytes
-        println!("Adding \"{}\"", std::str::from_utf8(buf).unwrap());
         self.adler32.update_buffer(buf);
         self.size += size;
         if self.position + size > buffer_size {
@@ -270,9 +264,6 @@ impl io::Write for FixedSizeAdler32 {
                 .clone_from_slice(&buf);
         }
         self.position = (self.position + size) % buffer_size;
-        println!("buffer = \"{}\"", std::str::from_utf8(&self.buffer).unwrap());
-        println!("position = {}", self.position);
-        println!();
         Ok(total_size)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,8 +302,9 @@ mod test {
     use rand;
     use rand::Rng;
     use std::io;
+    use std::io::Write;
 
-    use super::{BASE, adler32, RollingAdler32};
+    use super::{BASE, adler32, RollingAdler32, FixedSizeAdler32};
 
     fn adler32_slow<R: io::Read>(reader: R) -> io::Result<u32> {
         let mut a: u32 = 1;
@@ -375,5 +376,18 @@ mod test {
         do_test(b"", b"this a test");
         do_test(b"th", b"is a test");
         do_test(b"this a ", b"test");
+    }
+
+    #[test]
+    fn fixed_size() {
+        let mut rolling = FixedSizeAdler32::new(4);
+        rolling.write(b"12").unwrap();
+        assert_eq!(rolling.hash(), adler32(b"12" as &[u8]).unwrap());
+        rolling.write(b"3").unwrap();
+        assert_eq!(rolling.hash(), adler32(b"123" as &[u8]).unwrap());
+        rolling.write(b"45").unwrap();
+        assert_eq!(rolling.hash(), adler32(b"2345" as &[u8]).unwrap());
+        rolling.write(b"67890123").unwrap();
+        assert_eq!(rolling.hash(), adler32(b"0123" as &[u8]).unwrap());
     }
 }


### PR DESCRIPTION
This adds `FixedSizeAdler32`, that has a size set at construction, and keeps bytes in a cyclic buffer of that size to be removed when it fills up.

Current logic (and implementing Write) might be too much, since bytes will probably always be fed one by one anyway. Otherwise a faster way of removing a sequence might be needed (one by one is inefficient).