### PR TITLE
Use '?' instead of 'try'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,10 +196,10 @@ impl RollingAdler32 {
 pub fn adler32<R: io::Read>(mut reader: R) -> io::Result<u32> {
     let mut hash = RollingAdler32::new();
     let mut buffer = [0u8; NMAX];
-    let mut read = try!(reader.read(&mut buffer));
+    let mut read = reader.read(&mut buffer)?;
     while read > 0 {
         hash.update_buffer(&buffer[..read]);
-        read = try!(reader.read(&mut buffer));
+        read = reader.read(&mut buffer)?;
     }
     Ok(hash.hash())
 }
@@ -217,7 +217,7 @@ mod test {
         let mut b: u32 = 0;
 
         for byte in reader.bytes() {
-            let byte = try!(byte) as u32;
+            let byte = byte? as u32;
             a = (a + byte) % BASE;
             b = (b + a) % BASE;
         }


### PR DESCRIPTION
This gets rid of warnings about try being deprecated.