### PR TITLE
Mark library as `#![no_std]`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust-version: [1.17.0, 1.31.0, stable, nightly]
+        rust-version: [1.31.0, stable, nightly]
         include:
         - os: macos-latest
           rust-version: 1.31.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,20 @@ readme = "README.md"
 keywords = ["adler32", "hash", "rolling"]
 license = "Zlib"
 
+[dependencies]
+# Internal features, only used when building as part of libstd, not part of the
+# stable interface of this crate.
+core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
+compiler_builtins = { version = '0.1.2', optional = true }
+
+[features]
+default = ['std']
+std = []
+
+# Internal feature, only used when building as part of libstd, not part of the
+# stable interface of this crate.
+rustc-dep-of-std = ['core', 'compiler_builtins']
+
 [dev-dependencies]
 rand = "0.4"
 bencher = "0.1.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,13 @@
 //! the zlib implementation.
 
 #![forbid(unsafe_code)]
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
 
 #[cfg(test)]
 extern crate rand;
-
-use std::io;
 
 // adler32 algorithm and implementation taken from zlib; http://www.zlib.net/
 // It was translated into Rust as accurately as I could manage
@@ -194,7 +196,8 @@ impl RollingAdler32 {
 }
 
 /// Consume a Read object and returns the Adler32 hash.
-pub fn adler32<R: io::Read>(mut reader: R) -> io::Result<u32> {
+#[cfg(feature = "std")]
+pub fn adler32<R: std::io::Read>(mut reader: R) -> std::io::Result<u32> {
     let mut hash = RollingAdler32::new();
     let mut buffer = [0u8; NMAX];
     let mut read = reader.read(&mut buffer)?;
@@ -209,6 +212,8 @@ pub fn adler32<R: io::Read>(mut reader: R) -> io::Result<u32> {
 mod test {
     use rand::Rng;
     use std::io;
+    use std::prelude::v1::*;
+    use std::vec;
 
     use super::{adler32, RollingAdler32, BASE};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,8 +127,8 @@ impl RollingAdler32 {
         let byte = u32::from(byte);
         self.a = (self.a + BASE - byte) % BASE;
         self.b = ((self.b + BASE - 1)
-                      .wrapping_add(BASE.wrapping_sub(size as u32)
-                                        .wrapping_mul(byte))) % BASE;
+            .wrapping_add(BASE.wrapping_sub(size as u32).wrapping_mul(byte)))
+            % BASE;
     }
 
     /// Feeds a new `byte` to the algorithm to update the hash.
@@ -176,7 +176,8 @@ impl RollingAdler32 {
         }
 
         // do remaining bytes (less than NMAX, still just one modulo)
-        if pos < len { // avoid modulos if none remaining
+        if pos < len {
+            // avoid modulos if none remaining
             while len - pos >= 16 {
                 do16(&mut self.a, &mut self.b, &buffer[pos..pos + 16]);
                 pos += 16;
@@ -206,11 +207,10 @@ pub fn adler32<R: io::Read>(mut reader: R) -> io::Result<u32> {
 
 #[cfg(test)]
 mod test {
-    use rand;
     use rand::Rng;
     use std::io;
 
-    use super::{BASE, adler32, RollingAdler32};
+    use super::{adler32, RollingAdler32, BASE};
 
     fn adler32_slow<R: io::Read>(reader: R) -> io::Result<u32> {
         let mut a: u32 = 1;
@@ -240,11 +240,17 @@ mod test {
         do_test(0x024d0127, b"abc");
         do_test(0x29750586, b"message digest");
         do_test(0x90860b20, b"abcdefghijklmnopqrstuvwxyz");
-        do_test(0x8adb150c, b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
+        do_test(
+            0x8adb150c,
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                               abcdefghijklmnopqrstuvwxyz\
-                              0123456789");
-        do_test(0x97b61069, b"1234567890123456789012345678901234567890\
-                              1234567890123456789012345678901234567890");
+                              0123456789",
+        );
+        do_test(
+            0x97b61069,
+            b"1234567890123456789012345678901234567890\
+                              1234567890123456789012345678901234567890",
+        );
         do_test(0xD6251498, &[255; 64000]);
     }
 
@@ -252,8 +258,12 @@ mod test {
     fn compare() {
         let mut rng = rand::thread_rng();
         let mut data = vec![0u8; 5589];
-        for size in [0, 1, 3, 4, 5, 31, 32, 33, 67,
-                     5550, 5552, 5553, 5568, 5584, 5589].iter().cloned() {
+        for size in [
+            0, 1, 3, 4, 5, 31, 32, 33, 67, 5550, 5552, 5553, 5568, 5584, 5589,
+        ]
+        .iter()
+        .cloned()
+        {
             rng.fill_bytes(&mut data[..size]);
             let r1 = io::Cursor::new(&data[..size]);
             let r2 = r1.clone();
@@ -290,7 +300,7 @@ mod test {
         let w = 65536;
         assert!(w as u32 > BASE);
 
-        let mut bytes = vec![0; w*3];
+        let mut bytes = vec![0; w * 3];
         for (i, b) in bytes.iter_mut().enumerate() {
             *b = i as u8;
         }


### PR DESCRIPTION
Additionally also enable this library to be included into the standard
library itself with some `[dependencies]` and `[features]` voodoo. My
hope is to eventually enable the `backtrace` crate to depend on the
`gimli` crate for parsing DWARF information and symbolizing backtraces.
DWARF info in objects may be compressed though, and most zlib-related
crates use this crate! As a result if libstd is going to be
decompressing object files, we'll need to include this crate in the
standard library build itself.

If you've got any questions about this just let me know! I know it's a
bit odd, but unfortunately this is "as nice as it can be" for now at
least.