### PR TITLE
Convert to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "adler32"
 version = "1.1.0"
 authors = ["Remi Rampin <remirampin@gmail.com>"]
+edition = "2018"
 description = "Minimal Adler32 implementation for Rust."
 documentation = "https://docs.rs/adler32/"
 repository = "https://github.com/remram44/adler32-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,6 @@ rand = "0.4"
 bencher = "0.1.5"
 
 [[bench]]
+path = "src/bench.rs"
 name = "bench"
 harness = false

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,9 +1,4 @@
-#[macro_use]
-extern crate bencher;
-extern crate rand;
-extern crate adler32;
-
-use bencher::Bencher;
+use bencher::{Bencher, benchmark_main, benchmark_group};
 use rand::{thread_rng, Rng};
 use adler32::RollingAdler32;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,8 @@
 //! the zlib implementation.
 
 #![forbid(unsafe_code)]
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "std")]
-extern crate std;
-
-#[cfg(test)]
-extern crate rand;
 
 // adler32 algorithm and implementation taken from zlib; http://www.zlib.net/
 // It was translated into Rust as accurately as I could manage
@@ -213,8 +208,6 @@ pub fn adler32<R: std::io::Read>(mut reader: R) -> std::io::Result<u32> {
 mod test {
     use rand::Rng;
     use std::io;
-    use std::prelude::v1::*;
-    use std::vec;
 
     use super::{adler32, RollingAdler32, BASE};
 


### PR DESCRIPTION
Now that 1.31 is the MSRV anyway, switching to the 2018 edition is free.