### PR TITLE
Switch from `bencher` to `criterion`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust-version: [1.31.0, stable, nightly]
+        rust-version: [1.33.0, stable, nightly]
         include:
         - os: macos-latest
-          rust-version: 1.31.0
+          rust-version: 1.33.0
         - os: windows-latest
-          rust-version: 1.31.0
+          rust-version: 1.33.0
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,16 @@ std = []
 rustc-dep-of-std = ['core', 'compiler_builtins']
 
 [dev-dependencies]
+criterion = "0.3"
+humansize = "1.1"
 rand = "0.4"
-bencher = "0.1.5"
 
 [[bench]]
 path = "src/bench.rs"
 name = "bench"
 harness = false
+
+[lib]
+# Disable `libtest` so Criterion-only parameters like `--save-baseline` work.
+# See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false

--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ What is this?
 It is an implementation of the [Adler32 rolling hash algorithm](https://en.wikipedia.org/wiki/Adler-32) in the [Rust programming language](https://www.rust-lang.org/).
 
 It is adapted from Jean-Loup Gailly's and Mark Adler's [original implementation in zlib](https://github.com/madler/zlib/blob/2fa463bacfff79181df1a5270fb67cc679a53e71/adler32.c).
+
+
+#### Minimum Supported Version of Rust (MSRV)
+
+`adler32-rs` can be built with Rust version 1.33 or later. This version may be raised in the future but that will be accompanied by a minor version increase.


### PR DESCRIPTION
`Bencher` is a very bare-bones benchmarking harness that hasn't seen a commit in 2.5 years. In contrast `criterion` has all kinds of bells and whistles which simplify writing good benchmarks and help during result analysis.

The outlier detection and `--save-baseline` option alone are worth the switch. It nicely shows [improvements or regressions compared to the last run](https://user-images.githubusercontent.com/18645382/85309965-b1999700-b4b3-11ea-9efd-e2d8043c02ef.png) in the terminal, and if you want you can even study [more detailed reports](https://user-images.githubusercontent.com/18645382/85309993-b9f1d200-b4b3-11ea-86b7-186d288eee26.png).

This raises the MSRV (at least for dev workflows) to 1.33. Since even Debian oldstable is on 1.34 by now, I hope that will not be a problem.

Currently based on top of my 2018 edition PR from earlier. I can rebase if needed.