### PR TITLE
Update dependency `rand`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rustc-dep-of-std = ['core', 'compiler_builtins']
 [dev-dependencies]
 criterion = "0.3"
 humansize = "1.1"
-rand = "0.4"
+rand = "0.7"
 
 [[bench]]
 path = "src/bench.rs"

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,16 +1,17 @@
 use adler32::RollingAdler32;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use humansize::{file_size_opts, FileSize};
-use rand::{thread_rng, Rng};
+use rand::Rng;
 
 fn bench_update_buffer(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
     let mut group = c.benchmark_group("update_buffer");
     for &size in [512, 100 * 1024].iter() {
         let mut adler = RollingAdler32::new();
         let formatted_size = size.file_size(file_size_opts::BINARY).unwrap();
         let in_bytes = {
             let mut in_bytes = vec![0u8; size];
-            thread_rng().fill_bytes(&mut in_bytes);
+            rng.fill(&mut in_bytes[..]);
             in_bytes
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ mod test {
         .iter()
         .cloned()
         {
-            rng.fill_bytes(&mut data[..size]);
+            rng.fill(&mut data[..size]);
             let r1 = io::Cursor::new(&data[..size]);
             let r2 = r1.clone();
             if adler32_slow(r1).unwrap() != adler32(r2).unwrap() {


### PR DESCRIPTION
It's been a while since the last update. Requires Rust 1.32 which is fine since we just raised the MSRV to 1.33.