### PR TITLE
Disable benchmarking dependencies on older Rust versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,13 +52,13 @@ jobs:
     - name: Build
       run: cargo build --verbose $TARGET
     - name: Disable benchmarking dependencies
-      if: matrix.mode != 'native' || matrix.rust-version == '1.33.0'
-      run: "mv Cargo.toml Cargo.toml.bak && sed '/ # benchmark only$/d' Cargo.toml.bak >Cargo.toml"
+      if: matrix.mode != 'native' || matrix.rust-version != 'stable'
+      run: "mv Cargo.toml Cargo.toml.bak && sed '/ # benchmark only$/d' Cargo.toml.bak > Cargo.toml"
     - name: Run tests
       if: matrix.mode == 'native'
       run: cargo test --verbose
     - name: Run benchmarks
-      if: matrix.mode == 'native' && matrix.rust-version != '1.33.0'
+      if: matrix.mode == 'native' && matrix.rust-version == 'stable'
       run: cargo bench --verbose
     - name: Run wasm tests
       if: matrix.mode == 'wasm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,11 +51,14 @@ jobs:
         cargo install --version 0.9.1 wasm-pack
     - name: Build
       run: cargo build --verbose $TARGET
+    - name: Disable benchmarking dependencies
+      if: matrix.mode != 'native' || matrix.rust-version == '1.33.0'
+      run: "mv Cargo.toml Cargo.toml.bak && sed '/ # benchmark only$/d' Cargo.toml.bak >Cargo.toml"
     - name: Run tests
       if: matrix.mode == 'native'
       run: cargo test --verbose
     - name: Run benchmarks
-      if: matrix.mode == 'native'
+      if: matrix.mode == 'native' && matrix.rust-version != '1.33.0'
       run: cargo bench --verbose
     - name: Run wasm tests
       if: matrix.mode == 'wasm'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ std = []
 rustc-dep-of-std = ['core', 'compiler_builtins']
 
 [dev-dependencies]
-criterion = "=0.3.2" # 0.3.3 broken on Rust 1.33
-humansize = "1.1"
+criterion = "=0.3.2" # benchmark only
+humansize = "1.1" # benchmark only
 rand = "0.7"
 getrandom = { version = "0.1", features = ["wasm-bindgen"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ std = []
 rustc-dep-of-std = ['core', 'compiler_builtins']
 
 [dev-dependencies]
+# The lines marked 'benchmark only' get removed on CI for platforms/versions
+# where we don't run the benchmarks (e.g. versions not supported by criterion)
 criterion = "0.3" # benchmark only
 humansize = "1.1" # benchmark only
 rand = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ std = []
 rustc-dep-of-std = ['core', 'compiler_builtins']
 
 [dev-dependencies]
-criterion = "=0.3.2" # benchmark only
+criterion = "0.3" # benchmark only
 humansize = "1.1" # benchmark only
 rand = "0.7"
 getrandom = { version = "0.1", features = ["wasm-bindgen"] }


### PR DESCRIPTION
Remove `criterion` from `Cargo.toml` when building on Rust versions that don't support it.

See https://github.com/remram44/adler32-rs/pull/17#issuecomment-665934953

cc @LingMan what do you think?