### PR TITLE
Only test benchmarks on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,9 +57,9 @@ jobs:
     - name: Run tests
       if: matrix.mode == 'native'
       run: cargo test --verbose
-    - name: Run benchmarks
+    - name: Test benchmarks
       if: matrix.mode == 'native' && matrix.rust-version == 'stable'
-      run: cargo bench --verbose
+      run: cargo test --benches --verbose
     - name: Run wasm tests
       if: matrix.mode == 'wasm'
       run: wasm-pack test --node


### PR DESCRIPTION
Currently CI actually runs the benchmarks, however since CI systems are very
very noisy the results are basically meaningless. At the same time we want to
ensure that the benchmarking code works.

This can be archived by running `cargo test --benches` instead of `cargo bench`.

Significantly speeds up CI runs by
a) not performing warmup, sample collection, and analysis (~ 10 sec per benchmark)
b) not recompiling everything in release mode (~2m 40s).
Should shorten our current ~5 min CI runs down to ~2 min.